### PR TITLE
Added dotpay CHK parameter support and Symfony version requirments.

### DIFF
--- a/Controller/CallbackController.php
+++ b/Controller/CallbackController.php
@@ -93,7 +93,7 @@ class CallbackController extends Controller
             return new Response('FAIL', 500);
         }
 
-        $this->getDoctrine()->getEntityManager()->flush();
+        $this->getDoctrine()->getManager()->flush();
 
         $logger->info(sprintf('[Dotpay - URLC] Payment instruction %s successfully updated', $instruction->getId()));
 

--- a/Controller/CallbackController.php
+++ b/Controller/CallbackController.php
@@ -92,7 +92,7 @@ class CallbackController extends Controller
                 }
 
             } else {
-                $logger->err('[Dotpay - URLC] unable to create new transaction, deposited amount isn`t less then total amount');
+                $logger->err('[Dotpay - URLC] unable to create new transaction, all of amount has been deposited');
 
                 return new Response('FAIL', 500);
             }

--- a/Controller/CallbackController.php
+++ b/Controller/CallbackController.php
@@ -74,7 +74,7 @@ class CallbackController extends Controller
         if ($control !== $request->request->get('md5')) {
             $logger->err('[Dotpay - URLC - ' . $t_id .'] pin verification failed');
 
-            return new Response('FAIL', 500);
+            return new Response('FAIL SIGNATURE', 500);
         }
 
         // Handling payment:
@@ -90,13 +90,13 @@ class CallbackController extends Controller
                 if (null === $transaction) {
                     $logger->err('[Dotpay - URLC - ' . $t_id .'] error while creating new transaction');
 
-                    return new Response('FAIL', 500);
+                    return new Response('FAIL CREATING NEW TRANSACTION', 500);
                 }
 
             } else {
                 $logger->err('[Dotpay - URLC - ' . $t_id .'] unable to create new transaction, all of amount has been deposited');
 
-                return new Response('FAIL', 500);
+                return new Response('FAIL, TRANSACTION IS COMPLETED', 500);
             }
         }
 
@@ -109,7 +109,7 @@ class CallbackController extends Controller
         } catch (\Exception $e) {
             $logger->err(sprintf('[Dotpay - URLC - %s] %s', $t_id, $e->getMessage()));
 
-            return new Response('FAIL', 500);
+            return new Response('FAIL APPROVE AND DEPOSIT', 500);
         }
 
         $this->getDoctrine()->getManager()->flush();

--- a/Controller/CallbackController.php
+++ b/Controller/CallbackController.php
@@ -107,14 +107,14 @@ class CallbackController extends Controller
         try {
             $ppc->approveAndDeposit($transaction->getPayment()->getId(), $amount);
         } catch (\Exception $e) {
-            $logger->err(sprintf('[Dotpay - URLC - ' . $t_id .'] %s', $e->getMessage()));
+            $logger->err(sprintf('[Dotpay - URLC - %s] %s', $t_id, $e->getMessage()));
 
             return new Response('FAIL', 500);
         }
 
         $this->getDoctrine()->getManager()->flush();
 
-        $logger->info(sprintf('[Dotpay - URLC - ' . $t_id .'] Payment instruction %s successfully updated', $instruction->getId()));
+        $logger->info(sprintf('[Dotpay - URLC - %s] Payment instruction %s successfully updated', $t_id, $instruction->getId()));
 
         return new Response('OK');
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,7 +64,15 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('return_url')->defaultNull()->end()
+                            ->scalarNode('chk')
+                                ->defaultValue(false)
+                                ->validate()
+                                    ->ifNotInArray(array(true, false))
+                                    ->thenInvalid('Invalid type "%s"')
+                                ->end()
+                            ->end()
                         ->end()
+                
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,8 +64,8 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('return_url')->defaultNull()->end()
-                            ->scalarNode('chk')
-                                ->defaultValue(false)
+                            ->booleanNode('chk')
+                                ->defaultFalse()
                             ->end()
                         ->end()
                 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -67,6 +67,9 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('chk')
                                 ->defaultFalse()
                             ->end()
+                            ->booleanNode('recipientChk')
+                                ->defaultFalse()
+                            ->end()
                         ->end()
                 
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -70,6 +70,9 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('recipientChk')
                                 ->defaultFalse()
                             ->end()
+                            ->booleanNode('onlineTransfer')
+                                ->defaultFalse()
+                            ->end()
                         ->end()
                 
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,10 +66,6 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('return_url')->defaultNull()->end()
                             ->scalarNode('chk')
                                 ->defaultValue(false)
-                                ->validate()
-                                    ->ifNotInArray(array(true, false))
-                                    ->thenInvalid('Invalid type "%s"')
-                                ->end()
                             ->end()
                         ->end()
                 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -73,6 +73,9 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('onlineTransfer')
                                 ->defaultFalse()
                             ->end()
+                            ->integerNode('expirationTime')
+                                ->defaultValue(0)
+                            ->end()
                         ->end()
                 
                     ->end()

--- a/DependencyInjection/ETSPaymentDotpayExtension.php
+++ b/DependencyInjection/ETSPaymentDotpayExtension.php
@@ -49,5 +49,6 @@ class ETSPaymentDotpayExtension extends Extension
         $container->setParameter('payment.dotpay.direct.url', $config['direct']['url']);
         $container->setParameter('payment.dotpay.direct.type', $config['direct']['type']);
         $container->setParameter('payment.dotpay.direct.return_url', $config['direct']['return_url']);
+        $container->setParameter('payment.dotpay.direct.chk', $config['direct']['chk']);
     }
 }

--- a/DependencyInjection/ETSPaymentDotpayExtension.php
+++ b/DependencyInjection/ETSPaymentDotpayExtension.php
@@ -50,5 +50,6 @@ class ETSPaymentDotpayExtension extends Extension
         $container->setParameter('payment.dotpay.direct.type', $config['direct']['type']);
         $container->setParameter('payment.dotpay.direct.return_url', $config['direct']['return_url']);
         $container->setParameter('payment.dotpay.direct.chk', $config['direct']['chk']);
+        $container->setParameter('payment.dotpay.direct.recipientChk', $config['direct']['recipientChk']);
     }
 }

--- a/DependencyInjection/ETSPaymentDotpayExtension.php
+++ b/DependencyInjection/ETSPaymentDotpayExtension.php
@@ -51,5 +51,6 @@ class ETSPaymentDotpayExtension extends Extension
         $container->setParameter('payment.dotpay.direct.return_url', $config['direct']['return_url']);
         $container->setParameter('payment.dotpay.direct.chk', $config['direct']['chk']);
         $container->setParameter('payment.dotpay.direct.recipientChk', $config['direct']['recipientChk']);
+        $container->setParameter('payment.dotpay.direct.onlineTransfer', $config['direct']['onlineTransfer']);
     }
 }

--- a/DependencyInjection/ETSPaymentDotpayExtension.php
+++ b/DependencyInjection/ETSPaymentDotpayExtension.php
@@ -52,5 +52,6 @@ class ETSPaymentDotpayExtension extends Extension
         $container->setParameter('payment.dotpay.direct.chk', $config['direct']['chk']);
         $container->setParameter('payment.dotpay.direct.recipientChk', $config['direct']['recipientChk']);
         $container->setParameter('payment.dotpay.direct.onlineTransfer', $config['direct']['onlineTransfer']);
+        $container->setParameter('payment.dotpay.direct.expirationTime', $config['direct']['expirationTime']);
     }
 }

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -102,6 +102,7 @@ class DotpayDirectPlugin extends AbstractPlugin
      * @param string  $url         The urlc
      * @param integer $type        The type
      * @param string  $returnUrl   The return url
+     * @param boolean $returnUrl   Using DotPay CHK parameter, by default false
      */
     public function __construct(Router $router, Token $token, String $stringTools, $url, $type, $returnUrl, $chk = false)
     {
@@ -111,7 +112,7 @@ class DotpayDirectPlugin extends AbstractPlugin
         $this->returnUrl = $returnUrl;
         $this->url = $url;
         $this->type = $type;
-        $this->chk = $chk ? true : false;
+        $this->chk = $chk;
     }
 
     /**
@@ -196,17 +197,25 @@ class DotpayDirectPlugin extends AbstractPlugin
      */
     protected function generateChk(array $datas, $pin)
     {
-        $key = $datas['id'].
-                number_format($datas['amount'], 2, '.', '').
-               $datas['currency'].
-               rawurlencode($datas['description']).
-               (isset($datas['control']) ? $datas['control'] : '').
-               $pin;
+        $key =  $datas['id'];
+        $key .= number_format($datas['amount'], 2, '.', '');
+        $key .= $datas['currency'];
+        $key .= rawurlencode($datas['description']);
+        
+        if (isset($datas['control'])) {
+            $key .= $datas['control'];
+        }
+        
+        $key .= $pin;
         
         if (isset($datas['channel'])) {
-            $key .= $datas['channel'].
-                    (isset($datas['chlock']) ? $datas['chlock'] : '');
+            $key .= $datas['channel'];
+            
+            if (isset($datas['chlock'])) {
+                $key .= $datas['chlock'];
+            }
         }
+        
         return md5($key);
     }
 

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -183,8 +183,8 @@ class DotpayDirectPlugin extends AbstractPlugin
             'currency'    => $instruction->getCurrency(),
             'description' => sprintf('Payment Instruction #%d', $instruction->getId()),
 
-            'expirationDate' => $this->expirationTime > 0 ? date('Y-m-d H:i:s', time() + $this->expirationTime * 60) : null,
-            'maturityDate' => null
+            'data_waznosci' => $this->expirationTime > 0 ? date('Y-m-d H:i:s', time() + $this->expirationTime * 60) : null,
+            'data_zapadalnosci' => null
         );
 
         $additionalDatas = array(
@@ -249,12 +249,13 @@ class DotpayDirectPlugin extends AbstractPlugin
             }
         }
 
-        if (isset($datas['expirationDate'])) {
-            $key .= $datas['expirationDate'];
+        if (isset($datas['data_waznosci'])) {
 
-            if (isset($datas['maturityDate'])) {
-                $key .= $datas['maturityDate'];
+            if (isset($datas['data_zapadalnosci'])) {
+                $key .= $datas['data_zapadalnosci'];
             }
+
+            $key .= $datas['data_waznosci'];
         }
 
         if (isset($datas['recipientChk'])) {

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -197,7 +197,7 @@ class DotpayDirectPlugin extends AbstractPlugin
     protected function generateChk(array $datas, $pin)
     {
         $key = $datas['id'].
-               $datas['amount'].
+                number_format($datas['amount'], 2, '.', '').
                $datas['currency'].
                rawurlencode($datas['description']).
                (isset($datas['control']) ? $datas['control'] : '').

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -88,11 +88,6 @@ class DotpayDirectPlugin extends AbstractPlugin
      * @var integer
      */
     protected $type;
-    
-    /**
-     * @var integer
-     */
-    protected $type;
 
     /**
      * @var boolean

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -174,7 +174,7 @@ class DotpayDirectPlugin extends AbstractPlugin
 
         $datas = array(
             'id'                => $this->token->getId(),
-            'url'               => $this->getReturnUrl($extendedData),
+            'URL'               => $this->getReturnUrl($extendedData),
             'URLC'              => $urlc,
             'type'              => $this->type,
             'onlinetransfer'    => $this->onlineTransfer ? 1 : 0,

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -175,6 +175,12 @@ class DotpayDirectPlugin extends AbstractPlugin
             'street', 'phone', 'postcode', 'lastname',
             'firstname', 'email', 'country', 'city', 'grupykanalow',
         );
+        if ($this->recipientChk) {
+            $additionalDatas = array_merge($additionalDatas, array(
+                'recipientAccountNumber', 'recipientCompany', 'recipientFirstName', 'recipientLastName', 'recipientAddressStreet',
+                'recipientAddressBuilding', 'recipientAddressApartment', 'recipientAddressPostcode', 'recipientAddressCity'
+            ));
+        }
 
         foreach ($additionalDatas as $value) {
             if ($extendedData->has($value)) {

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -196,19 +196,18 @@ class DotpayDirectPlugin extends AbstractPlugin
      */
     protected function generateChk(array $datas, $pin)
     {
-        $fields = array('id', 'amount', 'currency', 'description', 'control', 'PIN');
-        if (!empty($datas['channel'])) {
-            $fields = array_merge($fields, array('channel', 'chlock'));
+        $key = $datas['id'].
+               $datas['amount'].
+               $datas['currency'].
+               rawurlencode($datas['description']).
+               (isset($datas['control']) ? $datas['control'] : '').
+               $pin;
+        
+        if (isset($datas['channel'])) {
+            $key .= $datas['channel'].
+                    (isset($datas['chlock']) ? $datas['chlock'] : '');
         }
-        $data = '';
-        foreach ($fields as $f) {
-            if ($f === 'PIN') {
-                $data .= $pin;
-            } else {
-                $data .= isset($datas[ $f ]) ? $datas[ $f ] : '';
-            }
-        }
-        return md5($data);
+        return md5($key);
     }
 
     /**

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -180,7 +180,7 @@ class DotpayDirectPlugin extends AbstractPlugin
 
         $additionalDatas = array(
             'street', 'phone', 'postcode', 'lastname', 'firstname',
-            'email', 'country', 'city', 'grupykanalow', 'street_n1', 'street_n2'
+            'email', 'country', 'city', 'grupykanalow', 'street_n1', 'street_n2', 'description'
         );
         if ($this->recipientChk) {
             $additionalDatas = array_merge($additionalDatas, array(

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -99,6 +99,11 @@ class DotpayDirectPlugin extends AbstractPlugin
      */
     protected $recipientChk;
 
+    /**
+     * @var boolean
+     */
+    protected $onlineTransfer;
+
 
     /**
      * @param Router  $router      The router
@@ -109,7 +114,7 @@ class DotpayDirectPlugin extends AbstractPlugin
      * @param string  $returnUrl   The return url
      * @param boolean $returnUrl   Using DotPay CHK parameter, by default false
      */
-    public function __construct(Router $router, Token $token, String $stringTools, $url, $type, $returnUrl, $chk = false, $recipientChk = false)
+    public function __construct(Router $router, Token $token, String $stringTools, $url, $type, $returnUrl, $chk = false, $recipientChk = false, $onlineTransfer = false)
     {
         $this->router = $router;
         $this->token = $token;
@@ -119,6 +124,7 @@ class DotpayDirectPlugin extends AbstractPlugin
         $this->type = $type;
         $this->chk = $chk;
         $this->recipientChk = $recipientChk;
+        $this->onlineTransfer = $onlineTransfer;
     }
 
     /**
@@ -165,6 +171,7 @@ class DotpayDirectPlugin extends AbstractPlugin
             'url'               => $this->getReturnUrl($extendedData),
             'URLC'              => $urlc,
             'type'              => $this->type,
+            'onlinetransfer'    => $this->onlineTransfer ? 1 : 0,
 
             'amount'      => $transaction->getRequestedAmount(),
             'currency'    => $instruction->getCurrency(),

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -108,7 +108,7 @@ class DotpayDirectPlugin extends AbstractPlugin
      * @param integer $type        The type
      * @param string  $returnUrl   The return url
      */
-    public function __construct(Router $router, Token $token, String $stringTools, $url, $type, $returnUrl, $chk)
+    public function __construct(Router $router, Token $token, String $stringTools, $url, $type, $returnUrl, $chk = false)
     {
         $this->router = $router;
         $this->token = $token;

--- a/Plugin/DotpayDirectPlugin.php
+++ b/Plugin/DotpayDirectPlugin.php
@@ -179,8 +179,8 @@ class DotpayDirectPlugin extends AbstractPlugin
         );
 
         $additionalDatas = array(
-            'street', 'phone', 'postcode', 'lastname',
-            'firstname', 'email', 'country', 'city', 'grupykanalow',
+            'street', 'phone', 'postcode', 'lastname', 'firstname',
+            'email', 'country', 'city', 'grupykanalow', 'street_n1', 'street_n2'
         );
         if ($this->recipientChk) {
             $additionalDatas = array_merge($additionalDatas, array(

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -27,6 +27,7 @@
             <argument>%payment.dotpay.direct.type%</argument>
             <argument>%payment.dotpay.direct.return_url%</argument>
             <argument>%payment.dotpay.direct.chk%</argument>
+            <argument>%payment.dotpay.direct.recipientChk%</argument>
             <tag name="payment.plugin" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,7 @@
             <argument>%payment.dotpay.direct.url%</argument>
             <argument>%payment.dotpay.direct.type%</argument>
             <argument>%payment.dotpay.direct.return_url%</argument>
+            <argument>%payment.dotpay.direct.chk%</argument>
             <tag name="payment.plugin" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -29,6 +29,7 @@
             <argument>%payment.dotpay.direct.chk%</argument>
             <argument>%payment.dotpay.direct.recipientChk%</argument>
             <argument>%payment.dotpay.direct.onlineTransfer%</argument>
+            <argument>%payment.dotpay.direct.expirationTime%</argument>
             <tag name="payment.plugin" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,7 +26,6 @@
             <argument>%payment.dotpay.direct.url%</argument>
             <argument>%payment.dotpay.direct.type%</argument>
             <argument>%payment.dotpay.direct.return_url%</argument>
-            <argument>%payment.dotpay.direct.chk%</argument>
             <tag name="payment.plugin" />
         </service>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -28,6 +28,7 @@
             <argument>%payment.dotpay.direct.return_url%</argument>
             <argument>%payment.dotpay.direct.chk%</argument>
             <argument>%payment.dotpay.direct.recipientChk%</argument>
+            <argument>%payment.dotpay.direct.onlineTransfer%</argument>
             <tag name="payment.plugin" />
         </service>
 

--- a/Tools/String.php
+++ b/Tools/String.php
@@ -16,6 +16,6 @@ class String
      */
     public function normalize($text)
     {
-        return preg_replace('/\pM*/u', '', normalizer_normalize($text, \Normalizer::FORM_D));
+        return preg_replace('/\pM*/u', '', \Normalizer::normalize($text, \Normalizer::FORM_D));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<=2.3.5",
+        "symfony/framework-bundle": ">=2.0,<2.4",
         "jms/payment-core-bundle": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ets/payment-dotpay-bundle",
+    "name": "pawellen-test/payment-dotpay-bundle",
     "type": "symfony-bundle",
     "description": "Payment Bundle providing access to the Dotpay API",
     "keywords": ["payment", "dotpay"],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.2-dev",
+        "symfony/framework-bundle": ">=2.0,<=2.3.5",
         "jms/payment-core-bundle": "dev-master"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pawellen-test/payment-dotpay-bundle",
+    "name": "ets/payment-dotpay-bundle",
     "type": "symfony-bundle",
     "description": "Payment Bundle providing access to the Dotpay API",
     "keywords": ["payment", "dotpay"],


### PR DESCRIPTION
1 changed:
Symfony version requirments change to <2.4

1 added:
Added support of CHK parameter. CHK parameter is used by dotpay do sing payment request. It is used to avoid generation of payments by anyone. The problem is that anyone can use this form https://ssl.dotpay.pl/payment/index.php or send false request to doypay about new payment. In this case you can generate many 0,01 transaction for witch the DotPay customer have to pay fee. The CHK parameter can be enabled by contact dotpay support tech@dotpay.pl. Email must be send from email associated with dotpay account.
