### PR TITLE
Upgrade supported version for php and symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 7.0
-  - 7.1
-  - 7.2
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
 env:
-  - SYMFONY_VERSION=2.3.*
-  - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=2.5.*
-  - SYMFONY_VERSION=2.6.*
-  - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
+  - SYMFONY_VERSION=3.0.*
+  - SYMFONY_VERSION=3.1.*
+  - SYMFONY_VERSION=3.2.*
+  - SYMFONY_VERSION=3.3.*
+  - SYMFONY_VERSION=3.4.*
 
 before_script:
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: php
+sudo: false
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - $HOME/symfony-bridge/.phpunit
 
 php:
   - '7.0'
@@ -14,6 +19,13 @@ env:
   - SYMFONY_VERSION=3.3.*
   - SYMFONY_VERSION=3.4.*
 
-before_script:
-  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
-  - composer install
+
+before_install:
+  - composer self-update
+  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+
+install:
+  - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction --prefer-dist $COMPOSER_FLAGS
+
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
 
 install:
-  - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction --prefer-dist $COMPOSER_FLAGS
+  - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpunit

--- a/Form/DirectType.php
+++ b/Form/DirectType.php
@@ -39,8 +39,16 @@ class DirectType extends AbstractType
     /**
      * @return string
      */
-    public function getBlockPrefix()
+    public function getName()
     {
         return 'dotpay_direct';
+    }
+
+    /**
+     * @return string
+     */
+    public function getBlockPrefix()
+    {
+        return $this->getName();
     }
 }

--- a/Form/DirectType.php
+++ b/Form/DirectType.php
@@ -39,7 +39,7 @@ class DirectType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'dotpay_direct';
     }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 ets_payment_dotpay_callback_urlc:
-    pattern:  /transaction/{id}/urlc
-    defaults: { _controller: ETSPaymentDotpayBundle:Callback:urlc }
+    path:  /transaction/{id}/urlc
+    controller: ETSPaymentDotpayBundle\Controller\CallbackController::urlc
+    methods: [GET, POST]
     requirements:
-        _method: GET|POST
         id: \d+

--- a/Tests/Plugin/DotpayDirectPluginTest.php
+++ b/Tests/Plugin/DotpayDirectPluginTest.php
@@ -22,6 +22,7 @@ namespace ETS\PurchaseBundle\Tests\Plugin;
 use ETS\Payment\DotpayBundle\Plugin\DotpayDirectPlugin;
 use JMS\Payment\CoreBundle\Model\FinancialTransactionInterface;
 use JMS\Payment\CoreBundle\Plugin\PluginInterface;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
@@ -29,7 +30,7 @@ use Prophecy\Argument;
  *
  * @author ETSGlobal <ecs@etsglobal.org>
  */
-class DotpayDirectPluginTest extends \PHPUnit_Framework_TestCase
+class DotpayDirectPluginTest extends TestCase
 {
     public function setUp()
     {

--- a/Tests/Tools/StringNormalizerTest.php
+++ b/Tests/Tools/StringNormalizerTest.php
@@ -3,6 +3,7 @@
 namespace ETS\PurchaseBundle\Tests\Tools;
 
 use ETS\Payment\DotpayBundle\Tools\StringNormalizer;
+use PHPUnit\Framework\TestCase;
 
 /*
  * Copyright 2012 ETSGlobal <ecs@etsglobal.org>
@@ -25,7 +26,7 @@ use ETS\Payment\DotpayBundle\Tools\StringNormalizer;
  *
  * @author ETSGlobal <ecs@etsglobal.org>
  */
-class StringNormalizerTest extends \PHPUnit_Framework_TestCase
+class StringNormalizerTest extends TestCase
 {
     /**
      * @return array

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,14 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "symfony/symfony": "~2.3",
-        "symfony/framework-bundle": "~2.3",
-        "jms/payment-core-bundle": "~1.0"
+        "php": ">=7.0",
+        "ext-intl": "*",
+        "symfony/symfony": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "jms/payment-core-bundle": "^1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": { "ETS\\Payment\\DotpayBundle\\": "" }


### PR DESCRIPTION
Unsupported version :
- PHP 5.4.*
- PHP 5.5.*
- Symfony 2.3.*
- Symfony 2.4.*
- Symfony 2.5.*
- Symfony 2.6.*
- Symfony 2.7.*

New supported version :
- PHP 7.3.*
- Symfony 3.0.*
- Symfony 3.1.*
- Symfony 3.2.*
- Symfony 3.4.*